### PR TITLE
Fix bug causing XDG Icon loader to use hicolor instead of png if svg is missing + add support for date and time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 rand = "0.8"
 freetype-rs = "0.37"
-freedesktop-icons = "0.3.1"
+freedesktop-icons = "0.4.0"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ toml = "0.8"
 rand = "0.8"
 freetype-rs = "0.37"
 freedesktop-icons = "0.4.0"
+chrono = { version = "0.4", features = ["unstable-locales"] }
+pure-rust-locales = "0.8"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/share/tiny-dfr/config.toml
+++ b/share/tiny-dfr/config.toml
@@ -55,7 +55,8 @@ PrimaryLayerKeys = [
     # Do not include the extension in the file name.
     # If a Theme is set, icons are looked up in XDG_DATA_DIRS.
     # Otherwise, they are first looked up in /etc/tiny-dfr, and then in /usr/share/tiny-dfr.
-    # Only one of Text or Icon is allowed,
+    # Time can be either 24hr, or 12hr. Locale is optional and will default to POSIX.
+    # Only one of Text, Icon or Time is allowed,
     # if both are present, the behavior is undefined.
     # For the list of supported key codes see
     # https://docs.rs/input-linux/latest/input_linux/enum.Key.html
@@ -90,6 +91,16 @@ PrimaryLayerKeys = [
     # { Text = "F10", Action = "F10", Stretch = 2 },
     # { Text = "F11", Action = "F11", Stretch = 2 },
     # { Text = "F12", Action = "F12", Stretch = 2 }
+
+    # Example of Time:
+    # { Time = "12hr",  Action = "Time"},
+    # Example of Time with locale:
+    # { Time = "12hr",  Locale = "en_IN", Action = "Time"},
+    # Example of Time with stretch:
+    # # the time key by default will be 3 times wider than the rest keys.
+    # # So the stretch value assigned will be 3 times the regular keys.
+    # { Time = "12hr",  Action = "Time", Stretch = 2},
+    # # Here, time key will be 3x2=6 times the normal keys.
 ]
 
 # This key defines the contents of the media key layer

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,8 @@ pub struct ButtonConfig {
     pub icon: Option<String>,
     pub text: Option<String>,
     pub theme: Option<String>,
+    pub time: Option<String>,
+    pub locale: Option<String>,
     pub action: Key,
     pub stretch: Option<usize>,
 }
@@ -89,6 +91,8 @@ fn load_config(width: u16) -> (Config, [FunctionLayer; 2]) {
                     theme: None,
                     action: Key::Esc,
                     stretch: None,
+                    time: None,
+                    locale: None,
                 },
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,14 +108,8 @@ fn try_load_image(name: impl AsRef<str>, theme: Option<impl AsRef<str>>) -> Resu
             lookup(name)
                 .with_cache()
                 .with_theme(theme)
-                .with_size(ICON_SIZE as u16)
-                .find(),
-            lookup(name)
-                .with_cache()
-                .with_theme(theme)
                 .force_svg()
                 .find(),
-            lookup(name).with_cache().with_theme(theme).find(),
         ];
 
         // .flatten() removes `None` and unwraps `Some` values


### PR DESCRIPTION
Currently the daemon prefers using svg icons for themes. But if svg is not available, it falls back hicolor to find svg icons instead of using png. This was because of a bug in the freedesktop-icons crate. I have forked the crate and opened a PR for a fix on [1]. Till them my fork with the fix can be used.

[1]: https://github.com/oknozor/freedesktop-icons/pull/26