### PR TITLE
Backlight: Support upstreamed mipi panel driver

### DIFF
--- a/etc/udev/rules.d/99-touchbar-tiny-dfr.rules
+++ b/etc/udev/rules.d/99-touchbar-tiny-dfr.rules
@@ -8,6 +8,7 @@ SUBSYSTEM=="drm", KERNEL=="card[0-9]*", DRIVERS=="adp|appletbdrm", TAG+="systemd
 
 SUBSYSTEM=="backlight", KERNEL=="appletb_backlight", DRIVERS=="hid-appletb-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
 SUBSYSTEM=="backlight", KERNEL=="228200000.display-pipe.0", DRIVERS=="panel-summit", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
+SUBSYSTEM=="backlight", KERNELS=="228600000.dsi.0", DRIVERS=="panel-summit", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
 
 SUBSYSTEM=="backlight", KERNEL=="apple-panel-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
 SUBSYSTEM=="backlight", KERNEL=="gmux_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"

--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -33,7 +33,7 @@ fn find_backlight() -> Result<PathBuf> {
         let file_name = entry.file_name();
         let name = file_name.to_string_lossy();
 
-        if ["display-pipe", "appletb_backlight"]
+        if ["display-pipe", "228600000.dsi.0", "appletb_backlight"]
             .iter()
             .any(|s| name.contains(s))
         {


### PR DESCRIPTION
I do not understand why `KERNEL=="228600000.dsi.0"` does not work. `udevadm info -a -p /sys/class/backlight/228600000.dsi.0` clearly lists that for the backlight device.