### PR TITLE
Updated Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729449015,
-        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
+        "lastModified": 1746957726,
+        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
+        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         in {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "tiny-dfr";
-            version = "0.3.4";
+            version = "0.3.5";
             src = ./.;
             cargoLock = { lockFile = ./Cargo.lock; };
             nativeBuildInputs = [ pkgs.pkg-config ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,21 @@
 {
   description = "The most basic dynamic function row daemon possible";
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
-  };
+  inputs = { nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11"; };
   outputs = { self, nixpkgs }:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       pkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-    in
-    rec {
-      packages = forAllSystems(system: 
-        let
-          pkgs = pkgsFor.${system};
-        in
-        {
+    in rec {
+      packages = forAllSystems (system:
+        let pkgs = pkgsFor.${system};
+        in {
           default = pkgs.rustPlatform.buildRustPackage {
-            name = "tiny-dfr";
-            version = "0.2.0";
+            pname = "tiny-dfr";
+            version = "0.3.4";
             src = ./.;
-            cargoLock = {
-              lockFile = ./Cargo.lock;
-            };
-            nativeBuildInputs = [
-              pkgs.pkg-config
-            ];
+            cargoLock = { lockFile = ./Cargo.lock; };
+            nativeBuildInputs = [ pkgs.pkg-config ];
             buildInputs = [
               pkgs.cairo
               pkgs.libinput
@@ -34,27 +25,30 @@
               pkgs.pango
               pkgs.gdk-pixbuf
               pkgs.libxml2
+              pkgs.librsvg
             ];
-          };
-        }
-      );
 
-      devShells = forAllSystems(system:
-        let
-          pkgs = pkgsFor.${system};
-        in
-        {
+            postConfigure = ''
+              substituteInPlace etc/systemd/system/tiny-dfr.service \
+                  --replace-fail /usr/bin $out/bin
+              substituteInPlace src/*.rs --replace-quiet /usr/share $out/share
+            '';
+
+            postInstall = ''
+              cp -R etc $out/lib
+              cp -R share $out
+            '';
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let pkgs = pkgsFor.${system};
+        in {
           default = pkgs.mkShell {
-            inputsFrom = [
-              packages.${system}.default
-            ];
-            packages = [
-    	        pkgs.rustfmt
-              pkgs.rust-analyzer
-            ];
+            inputsFrom = [ packages.${system}.default ];
+            packages = [ pkgs.rustfmt pkgs.rust-analyzer ];
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
           };
-        }
-      );
+        });
     };
 }


### PR DESCRIPTION
The Nix flake wasn't building with the latest Cargo dependencies. This updated flake should be working properly. It also correctly installs the files into /share and /etc, which was not being done before.