### PR TITLE
Custom time string

### DIFF
--- a/share/tiny-dfr/config.toml
+++ b/share/tiny-dfr/config.toml
@@ -93,14 +93,18 @@ PrimaryLayerKeys = [
     # { Text = "F12", Action = "F12", Stretch = 2 }
 
     # Example of Time:
-    # { Time = "12hr",  Action = "Time"},
+    # { Time = "12hr",  Action = "Time", Stretch = 3},
     # Example of Time with locale:
-    # { Time = "12hr",  Locale = "en_IN", Action = "Time"},
+    # { Time = "12hr",  Locale = "en_IN", Action = "Time", Stretch = 3},
     # Example of Time with stretch:
     # # the time key by default will be 3 times wider than the rest keys.
     # # So the stretch value assigned will be 3 times the regular keys.
     # { Time = "12hr",  Action = "Time", Stretch = 2},
     # # Here, time key will be 3x2=6 times the normal keys.
+    # You can also put in your format string directly.
+    # The available variables can be found here: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+    # If your time block says "Time format error" you are using some invalid parameter.
+    # { Time = "%H:%M %-e.%m.%Y", Action = "Time", Stretch = 2}
 ]
 
 # This key defines the contents of the media key layer


### PR DESCRIPTION
I added the option to use a custom string for the time / date, using all of the available variables in `format_localized`.
I have removed the `stretch * 3` part as users can now make a smaller time string, fitting on as little as one slot.